### PR TITLE
Local deployment #84

### DIFF
--- a/Docker/irc/Dockerfile
+++ b/Docker/irc/Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu:latest
+RUN apt update -y
+RUN apt install -y ircd-irc2
+
+EXPOSE 6667
+
+CMD ["/usr/sbin/ircd", "-t"]

--- a/Docker/nutrient/Dockerfile
+++ b/Docker/nutrient/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.4-alpine
+ADD . /code
+WORKDIR /code
+CMD ["python", "run.py"]
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '2'
+services:
+  irc:
+    build: ./Docker/irc
+    ports:
+      - "6667:6667"
+
+  nutrient:
+    depends_on:
+      - irc
+    restart: always
+    build: ./Docker/nutrient
+    volumes:
+      - .:/code
+    environment:
+      NB_USER: "nutri"
+      NB_SERVER: "irc"
+      NB_CHANNEL: "#nbchannel"

--- a/run.py
+++ b/run.py
@@ -1,3 +1,4 @@
+import os
 import re
 import socket
 
@@ -26,12 +27,12 @@ def ping():
 # This is a main routine
 def main():
     global irc, user_queue
-    botnick = "nutrient-bot"
+    botnick = os.environ.get("NB_USER", "nutrient-bot")
     bufsize = 2048
     admin = ["rahuldecoded"]
-    channel = "#uit-foss"
-    port = 6667
-    server = "irc.freenode.net"
+    channel = os.environ.get("NB_CHANNEL", "#uit-foss")
+    port = int(os.environ.get("NB_PORT", 6667))
+    server = os.environ.get("NB_SERVER", "irc.freenode.net")
     master = "rahuldecoded"
     uname = "Nutrient Bot"
     realname = "I'm a Test Bot!"


### PR DESCRIPTION
For #84. Uses docker-compose to spin up local IRC server and bot in containers. Additionally updates to use environment variables for some values that are currently hard-coded.

Requires `docker` and `docker-compose`.

To run, use `docker-compose up` within the root directory of the repo. This will build and run the containers.